### PR TITLE
Add create and abort flags to bypass interactive prompt

### DIFF
--- a/cmd/venv/main.go
+++ b/cmd/venv/main.go
@@ -13,12 +13,16 @@ import (
 var (
 	help    bool // The --help flag
 	version bool // The --version flag
+	create  bool // The --create flag to bypass the interactive prompt
+	abort   bool // The --abort flag to bypass the interactive prompt
 )
 
 func main() {
 	// Set up flags
 	flag.BoolVar(&help, "help", false, "--help")
 	flag.BoolVar(&version, "version", false, "--version")
+	flag.BoolVar(&create, "create", false, "--create")
+	flag.BoolVar(&abort, "abort", false, "--abort")
 
 	app := cli.New(os.Stdout, os.Stderr, afero.NewOsFs(), msg.Default())
 
@@ -41,7 +45,7 @@ func main() {
 		app.Version()
 	default:
 		// Run the actual program
-		if err := app.Run(); err != nil {
+		if err := app.Run(create, abort); err != nil {
 			prefix := msg.Sfail("Error:")
 			msg.Textf("%s %s", prefix, err)
 			os.Exit(1)


### PR DESCRIPTION
<!-- Provide a brief summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
This PR adds two optional flags: `--create` and `--abort` which can be
used to bypass the fallback interactive prompt should the environment
auto-detection not resolve.

The flags specify the equivalent behaviour of their interactive counterparts
and are mutually exclusive. If used together, the program will error and exit.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Closes #13

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- Include details of your testing environment, tests ran to see how -->
<!-- your change affects other areas of the code, etc. -->
<!-- If you ran a nox session for example -->
- [x] I have tested using **MacOS**
- [ ] I have tested using **Linux**
- [ ] I have tested using **Windows**

#### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have updated the documentation accordingly.
- [ ] I have updated the tests accordingly.
